### PR TITLE
add data release to cloud config

### DIFF
--- a/etc/compose.yaml
+++ b/etc/compose.yaml
@@ -44,6 +44,9 @@ services:
       SLICK_CLICKHOUSE_URL: "jdbc:clickhouse://clickhouse:8123"
       ELASTICSEARCH_HOST: "opensearch"
       PLATFORM_API_IGNORE_CACHE: "${PLATFORM_API_IGNORE_CACHE:-false}"
+      META_DATA_RELEASE: "${OT_RELEASE:-25.09}"
+      META_PRODUCT_NAME: "${OT_WEBAPP_FLAVOR:-platform}"
+      META_API_VERSION: "${OT_API_TAG}"
     ports:
       - 8081:8080
     depends_on:

--- a/etc/defaults-cloud
+++ b/etc/defaults-cloud
@@ -13,7 +13,8 @@ TF_VAR_OT_SUBDOMAIN_NAME="" # leave default empty so it is generated randomly by
 TF_VAR_OT_DAYS_TO_LIVE="2"
 OT_WEBAPP_FLAVOR="platform"
 
-# Data snapshots
+# Data versions
+OT_RELEASE="25.09"
 TF_VAR_OT_SNAPSHOT_CH="platform-2509-ch"
 TF_VAR_OT_SNAPSHOT_OS="platform-2509-os"
 


### PR DESCRIPTION
- Added Release config (same as in local config) to the cloud config and compose file. 
- Means that api is compatible with the >=25.09 releases of the data, which have namespacing based on the data release version.